### PR TITLE
Fixed subject encoding issues; Added importance to priority mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ docker build -t cyrinux/imap2gotify .
 
 - Check `settings.toml.example` example in `config` directory.
 
+- If no `priority` setting is specified for a rule, priority will be based on the
+  "importance" mail header, mapping as follows:
+    - High -> priority 7
+    - Medium -> priority 4
+    - Low -> priority 3
+    - priority 1 for all others
+
 - "extras" parameters can be found [here](https://gotify.net/docs/msgextras)
-
-# TODO
-
-- Add priority based on mail headers / flags


### PR DESCRIPTION
* The current get_subject was not respecting multi-encoded subjects, and returning bytes.  By using str(make_header(decode_header(...))) will properly decode all subjects to a Python string for all cases.

https://stackoverflow.com/a/7331577 has an explanation, with Python3 version (replacing unicode() with str()) in the comments

* Implemented mail "priority" to Gotify priority mapping.  Using "importance" header, values are mapped similar to Gotify's android client channels (low -> 3, medium ->4, high ->7).  All other cases priority is set to 1. Mapping will always be overridden by rules that have an explicit priority set