### PR TITLE
Added back html2text handling for html messages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ chardet==4.0.0
 colorama==0.4.4
 distlib==0.3.1
 filelock==3.0.12
+html2text==2020.1.16
 idna==2.10
 IMAPClient==2.2.0
 packaging==20.9


### PR DESCRIPTION
Addressing issue #3 

Created method to decode html formatted messages in the event a plain version is not in the message body.