### PR TITLE
Fixed unmatched marked as read issue, renamed vars to reflect type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 *.toml
 __pycache__
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/imap2gotify.py
+++ b/imap2gotify.py
@@ -33,12 +33,12 @@ class Imap2Gotify:
                 # those messages that were succefully sent via gotify are
                 # then marked as read
                 new_messages = client.get_unread()
-                (matched_messages, not_matched_messages) = rules.check_matches(
+                (matched_results, not_matched_results) = rules.check_matches(
                     new_messages
                 )
-                client.mark_as_read(not_matched_messages)
-                if matched_messages:
-                    gotify_sent_messages = gotify.send(matched_messages)
+                client.mark_as_read([r.message for r in not_matched_results])
+                if matched_results:
+                    gotify_sent_messages = gotify.send(matched_results)
                     client.mark_as_read(gotify_sent_messages)
 
                 # Go into idle waiting for new emails


### PR DESCRIPTION
For messages that do not have a matching rule (and will subsequently be marked as READ), the structure type being sent was of MatchResults type, but the Imap.mark_as_read() expects EmailStruct type.

Extract out the EmailStruct type (line 39) and changed variable names to reflect the correct types (results instead of messages)

Also added "standard" python virtual environments to .gitignore